### PR TITLE
CHANGE(tuned): Add `openio_tuned_profile_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 | `openio_tuned_cpu` | `"{{ cpu_performance }}"` | dict of settings CPU |
 | `openio_tuned_disk` | `"{{ disk_rotational }}"` | dict of settings DISK |
 | `openio_tuned_package_upgrade` | `"{{ openio_package_upgrade | d(false) }}"` | Set the packages to the latest version (to be set in extra_vars) |
+| `openio_tuned_profile_name` | `openio` | Name of the tuned profile |
 | `openio_tuned_redis_hosts` | `"{{ groups['redis'] | d([]) }}"` | Ansible group of hosts for the redis backend |
 | `openio_tuned_scsi_host` | `"{{ scsi_host_performance }}"` | dict of settings SCSI HOST |
 | `openio_tuned_sysconfig_dir` | `/etc/tuned/openio` | Folder of the profile openio_tuned_configname |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
-openio_tuned_sysconfig_dir: /etc/tuned/openio
+openio_tuned_sysconfig_dir: /etc/tuned
 openio_tuned_configname: tuned.conf
+openio_tuned_profile_name: openio
 
 openio_tuned_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Create profile directory
   file:
-    path: "{{ openio_tuned_sysconfig_dir }}"
+    path: "{{ openio_tuned_sysconfig_dir }}/{{ openio_tuned_profile_name }}"
     state: directory
     owner: root
     group: root
@@ -36,7 +36,7 @@
 - name: Copy the tuned profile
   template:
     src: tuned.conf.j2
-    dest: "{{ openio_tuned_sysconfig_dir }}/{{ openio_tuned_configname }}"
+    dest: "{{ openio_tuned_sysconfig_dir }}/{{ openio_tuned_profile_name }}/{{ openio_tuned_configname }}"
     owner: root
     group: root
     mode: 0644
@@ -52,12 +52,10 @@
   tags: configure
 
 - name: Set tuned tuned profile.
-  command: "/usr/sbin/tuned-adm profile {{ profile }}"
+  command: "/usr/sbin/tuned-adm profile {{ openio_tuned_profile_name }}"
   ignore_errors: "{{ ansible_check_mode }}"
-  vars:
-    profile: "{{ openio_tuned_sysconfig_dir | basename }}"
   when:
     - ansible_virtualization_type != 'docker'
-    - "{{ profile }} not in tuned_active.stdout"
+    - "{{ openio_tuned_profile_name }} not in tuned_active.stdout"
   tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

Specify a profile name instead of inferring it from the path.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION