### PR TITLE
BUMP(tuned): CI - Set requirements.yml to `20.04`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://travis-ci.org/open-io/ansible-role-openio-tuned.svg?branch=19.04)](https://travis-ci.org/open-io/ansible-role-openio-tuned)
+[![Build Status](https://travis-ci.org/open-io/ansible-role-openio-tuned.svg?branch=20.04)](https://travis-ci.org/open-io/ansible-role-openio-tuned)
 # Ansible role `tuned`
 
 - install tuned

--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,5 +1,5 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-users.git
-  version: "19.04"
+  version: "20.04"
   name: users
 ...


### PR DESCRIPTION
 ##### SUMMARY

In order to be able to test the roles in `20.04`, it is necessary to change the branches in this file.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION